### PR TITLE
Also use setuptools' extras_require which contains complex dependencies

### DIFF
--- a/lib/fpm/package/pyfpm/get_metadata.py
+++ b/lib/fpm/package/pyfpm/get_metadata.py
@@ -90,6 +90,11 @@ class get_metadata(Command):
                 for dep in pkg_resources.parse_requirements(
                         self.distribution.install_requires):
                     final_deps.extend(self.process_dep(dep))
+            if getattr(self.distribution, 'extras_require', None):
+                for dep in pkg_resources.parse_requirements(
+                        v for k, v in self.distribution.extras_require.items()
+                        if k.startswith(':') and pkg_resources.evaluate_marker(k[1:])):
+                    final_deps.extend(self.process_dep(dep))
 
         data["dependencies"] = final_deps
 


### PR DESCRIPTION
ex. 'charset_normalizer~=2.0.0; python_version >= "3"' is now included if the marker matches the build environment.